### PR TITLE
BF+DOC - update, clarify numpy dependency

### DIFF
--- a/datarray/__init__.py
+++ b/datarray/__init__.py
@@ -8,8 +8,9 @@ import distutils.version as v
 
 # Third-party
 import numpy as np
+# datarray uses the __array_prepare__ method introduced in numpy 1.4.0
 if v.LooseVersion(np.__version__) < v.LooseVersion('1.4'):
-    raise ImportError('Numpy version > 1.4 is required to use datarray')
+    raise ImportError('Numpy version >= 1.4 is required to use datarray')
 
 # Our own
 try:


### PR DESCRIPTION
Numpy dependency of >= 1.4.0 seems to be due to need for
**array_prepare** method.
