### PR TITLE
MRG: fix tests for Python 2 and 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - python: 2.7
       env:
         # Check numpy minimum version in datarray/version.py
-        - DEPENDS="numpy==1.5.1"
+        - DEPENDS="numpy==1.7.0"
     - python: 2.7
       env:
         - INSTALL_TYPE=sdist

--- a/datarray/datarray.py
+++ b/datarray/datarray.py
@@ -1190,14 +1190,24 @@ class DataArray(np.ndarray):
     # -- Reductions ----------------------------------------------------------
     mean = _apply_reduction('mean', ('axis', 'dtype', 'out'))
     var = _apply_reduction('var', ('axis', 'dtype', 'out', 'ddof'))
-    std = _apply_reduction('std', ('axis', 'dtype', 'out', 'ddof'))
+
+    def std(self, *args, **kwargs):
+        ret = self.var(*args, **kwargs)
+        if isinstance(ret, np.ndarray):
+            ret = np.sqrt(ret, out=ret)
+        elif hasattr(ret, 'dtype'):
+            ret = ret.dtype.type(np.sqrt(ret))
+        else:
+            ret = np.sqrt(ret)
+        return ret
+    std.__doc__ = np.ndarray.std.__doc__
 
     min = _apply_reduction('min', ('axis', 'out'))
     max = _apply_reduction('max', ('axis', 'out'))
 
     sum = _apply_reduction('sum', ('axis', 'dtype', 'out'))
     prod = _apply_reduction('prod', ('axis', 'dtype', 'out'))
-    
+
     ### these change the meaning of the axes..
     ### should probably return ndarrays
     argmax = _apply_reduction('argmax', ('axis',))

--- a/datarray/datarray.py
+++ b/datarray/datarray.py
@@ -1042,7 +1042,7 @@ class DataArray(np.ndarray):
         # form a transpose operation with axes specified
         # by (axis1, axis2) swapped
         axis1, axis2 = _names_to_numbers(self.axes, [axis1, axis2])
-        ax_idx = range(self.ndim)
+        ax_idx = list(range(self.ndim))
         tmp = ax_idx[axis1]
         ax_idx[axis1] = ax_idx[axis2]
         ax_idx[axis2] = tmp

--- a/datarray/datarray.py
+++ b/datarray/datarray.py
@@ -989,9 +989,9 @@ class DataArray(np.ndarray):
             _set_axes(self, new_axes)
 
             # Pop the axes off in descending order to prevent index renumbering
-            # headaches 
-            reductions = list(reversed(sorted(zip(key, new_axes), 
-                                         key=lambda ax: ax.index)))
+            # headaches.
+            reductions = list(reversed(sorted(zip(key, new_axes),
+                                              key=lambda t: t[1].index)))
             arr = self
             for k,ax in reductions:
                 arr = arr.axes[ax.index][k]

--- a/datarray/print_grid.py
+++ b/datarray/print_grid.py
@@ -218,16 +218,21 @@ class ComplexFormatter(GridDataFormatter):
         result = '{0}{1}j'.format(real_part, imag_part)
         return '{0:<{width}}'.format(result, width=width)
 
+
+# Formatters for numpy dtype kinds
+_KIND2FORMAT = dict(b = BoolFormatter,
+                    u = IntFormatter,
+                    i = IntFormatter,
+                    f = FloatFormatter,
+                    c = ComplexFormatter)
+
+
 def get_formatter(arr):
     """
     Get a formatter for this array's data type, and prime it on this array.
     """
-    typeobj = arr.dtype.type
-    if issubclass(typeobj, np.bool): return BoolFormatter(arr)
-    elif issubclass(typeobj, np.int): return IntFormatter(arr)
-    elif issubclass(typeobj, np.floating): return FloatFormatter(arr)
-    elif issubclass(typeobj, np.complex): return ComplexFormatter(arr)
-    else: return StrFormatter(arr)
+    return _KIND2FORMAT.get(arr.dtype.kind, StrFormatter)(arr)
+
 
 def grid_layout(arr, width=75, height=10):
     """

--- a/datarray/print_grid.py
+++ b/datarray/print_grid.py
@@ -1,8 +1,11 @@
 """
 Functions for pretty-printing tabular data, such as a DataArray, as a grid.
 """
+import sys
+if sys.version_info[0] < 3:
+    range = xrange
+
 import numpy as np
-import itertools
 
 class GridDataFormatter(object):
     """
@@ -305,7 +308,7 @@ def labeled_layout(arr, width=75, height=10, row_label_width=9):
         labels = cells_shown.axes[0].labels
         offset = 0
         if arr.axes[1].labels: offset = 1
-        for r in xrange(cells_shown.shape[0]):
+        for r in range(cells_shown.shape[0]):
             layout[r+offset][0] = label_formatter.format(str(labels[r]), row_label_width)
     
     if row_header or col_header:

--- a/datarray/print_grid.py
+++ b/datarray/print_grid.py
@@ -34,7 +34,7 @@ class GridDataFormatter(object):
         if self.data is None:
             # no information, so just use all the space we're given
             return 100
-        return max([len(unicode(val)) for val in self.data.flat])
+        return max([len(str(val)) for val in self.data.flat])
 
     def format(self, value, width=None):
         """

--- a/datarray/tests/test_bugfixes.py
+++ b/datarray/tests/test_bugfixes.py
@@ -53,12 +53,17 @@ def test_bug34():
     from datarray.print_grid import datarray_to_string
     from datetime import date as D
     A = DataArray([[1,2],[3,4]], [('row', ('a', D(2010,1,1))),('col', 'cd')])
-    nt.assert_equal(datarray_to_string(A), """row       col                
+    exp_out = """row       col                
 --------- -------------------
           c         d        
 a                 1         2
-2010-01-0         3         4""")
-    
+2010-01-0         3         4"""
+    nt.assert_equal(datarray_to_string(A), exp_out)
+    # Output for unsigned integers
+    B = A.astype(np.uint32)
+    nt.assert_equal(datarray_to_string(B), exp_out)
+
+
 def test_bug35():
     "Bug 35"
     txt_array = DataArray(['a','b'], axes=['dummy'])

--- a/datarray/tests/test_bugfixes.py
+++ b/datarray/tests/test_bugfixes.py
@@ -71,15 +71,15 @@ def test_bug35():
 def test_bug38():
     "Bug 38: DataArray.__repr__ should parse as a single entity"
     # Calling repr() on an ndarray prepends array (instead of np.array)
-    array = np.array
     arys = (
         DataArray(np.random.randint(0, 10000, size=(1,2,3,4,5)), 'abcde'),
         DataArray(np.random.randint(0, 10000, size=(3,3,3))), # Try with missing axes
         DataArray(np.random.randint(0, 10000, (2,4,5,6)), # Try with ticks
             ('a', ('b', ('b1','b2','b3','b4')), 'c', 'd')),
         )
+    # Load `array` into namespace for `eval`
+    array = np.array
     for A in arys:
-        print A
         assert_datarray_equal(A, eval(repr(A)))
 
 def test_bug44():

--- a/datarray/tests/test_data_array.py
+++ b/datarray/tests/test_data_array.py
@@ -88,13 +88,15 @@ def test_1d():
     adata = [2,3]
     a = DataArray(adata, 'x', int)
     # Verify scalar extraction
-    nt.assert_true(isinstance(a.axes.x[0], int))
+    nt.assert_true(np.isscalar(a.axes.x[0]))
+    nt.assert_equal(np.dtype(a.axes.x[0]), np.dtype(np.int))
     # Verify indexing of axis
     nt.assert_equals(a.axes.x.index, 0)
     # Iteration checks
     for i,val in enumerate(a.axes.x):
         nt.assert_equals(val, adata[i])
-        nt.assert_true(isinstance(val, int))
+        nt.assert_true(np.isscalar(val))
+        nt.assert_equal(np.dtype(val), np.dtype(np.int))
 
 def test_2d():
     b = DataArray([[1,2],[3,4],[5,6]], 'xy')

--- a/datarray/tests/test_data_array.py
+++ b/datarray/tests/test_data_array.py
@@ -1,5 +1,8 @@
 '''Tests for DataArray and friend'''
 
+import sys
+PY3 = sys.version_info[0] >= 3
+
 import numpy as np
 
 from datarray.datarray import Axis, DataArray, NamedAxisError, \
@@ -446,7 +449,10 @@ def test_label_mismatch():
     nt.assert_raises(NamedAxisError, dar1.__add__, dar2)
     nt.assert_raises(NamedAxisError, dar1.__sub__, dar2)
     nt.assert_raises(NamedAxisError, dar1.__mul__, dar2)
-    nt.assert_raises(NamedAxisError, dar1.__div__, dar2)
+    nt.assert_raises(NamedAxisError, dar1.__floordiv__, dar2)
+    nt.assert_raises(NamedAxisError, dar1.__truediv__, dar2)
+    if not PY3:
+        nt.assert_raises(NamedAxisError, dar1.__div__, dar2)
     
 # -- Test DataArray.axes
 class TestAxesManager:

--- a/datarray/version.py
+++ b/datarray/version.py
@@ -128,4 +128,4 @@ ISRELEASED          = False
 VERSION             = __version__
 PACKAGES            = ["datarray", "datarray/tests", "datarray/testing"]
 PACKAGE_DATA        = {'datarray': ['LICENSE']}
-REQUIRES            = ["numpy"]
+REQUIRES            = ["numpy (>=1.7)"]

--- a/doc/source/basic_data_array.rst
+++ b/doc/source/basic_data_array.rst
@@ -13,7 +13,9 @@
 Basic DataArray Creation And Mixing
 ===================================
 
-DataArrays are constructed with array-like sequences and axis names::
+DataArrays are constructed with array-like sequences and axis names:
+
+.. doctest::
 
     >>> narr = DataArray(np.zeros((1,2,3)), axes=('a', 'b', 'c'))
     >>> narr.names
@@ -28,20 +30,26 @@ DataArrays are constructed with array-like sequences and axis names::
     (1, 2, 3)
 
 Not all axes must necessarily be explicitly named, since None is a valid axis
-name::
+name:
+
+.. doctest::
 
     >>> narr2 = DataArray(np.zeros((1,2,3)), axes=('a', None, 'b' ))
     >>> narr2.names
     ('a', None, 'b')
 
 If no name is given for an axis, None is implicitly assumed.  So trailing axes
-without axes will be named as None::
+without axes will be named as None:
+
+.. doctest::
 
     >>> narr2 = DataArray(np.zeros((1,2,3,2)), axes=('a','b' ))
     >>> narr2.names
     ('a', 'b', None, None)
 
-Combining named and unnamed arrays::
+Combining named and unnamed arrays:
+
+.. doctest::
 
     >>> narr = DataArray(np.zeros((1,2,3)), axes='abc')
     >>> res = narr + 5 # OK
@@ -58,7 +66,8 @@ Combining named and unnamed arrays::
 
 
 Now, what about matching names, but different indices for the names?
-::
+
+.. doctest::
 
     >>> n4 = DataArray(np.ones((2,1,3)), axes=('b','a','c'))
     >>> res = narr + n4 # is this OK?
@@ -72,7 +81,9 @@ raise an error.  At least for now we will raise an error, and review later.
 With "labels"
 -------------
 
-Constructing a DataArray such that an Axis has labels, for example::
+Constructing a DataArray such that an Axis has labels, for example:
+
+.. doctest::
 
     >>> cap_ax_spec = 'capitals', ['washington', 'london', 'berlin', 'paris', 'moscow']
     >>> time_ax_spec = 'time', ['0015', '0615', '1215', '1815']
@@ -87,19 +98,23 @@ Slicing
 
 A DataArray with simple named axes can be sliced many ways.
 
-Per Axis::
+Per Axis:
+
+.. doctest::
 
     >>> narr = DataArray(np.zeros((1,2,3)), axes=('a','b','c'))
     >>> narr.axes.a
     Axis(name='a', index=0, labels=None)
     >>> narr.axes.a[0]
-    DataArray([[ 0.,  0.,  0.],
-           [ 0.,  0.,  0.]])
-    ('b', 'c')
+    DataArray(array([[ 0.,  0.,  0.],
+           [ 0.,  0.,  0.]]),
+    ('b', 'c'))
     >>> narr.axes.a[0].axes
     (Axis(name='b', index=0, labels=None), Axis(name='c', index=1, labels=None))
 
-By normal "numpy" slicing::
+By normal "numpy" slicing:
+
+.. doctest::
 
     >>> narr[0].shape
     (2, 3)
@@ -108,7 +123,9 @@ By normal "numpy" slicing::
     >>> narr.axes.a[0].axes == narr[0,:].axes
     True
 
-Also, slicing with ``newaxis`` is implemented::
+Also, slicing with ``newaxis`` is implemented:
+
+.. doctest::
 
     >>> arr = np.arange(24).reshape((3,2,4))
     >>> b = DataArray(arr, ['x', 'y', 'z'])
@@ -119,7 +136,9 @@ Also, slicing with ``newaxis`` is implemented::
 
 I can also slice with ``newaxis`` at each Axis.  The effect of this is always
 to insert an unnamed Axis with length-1 at the original index of the named
-Axis::
+Axis:
+
+.. doctest::
 
     >>> b.axes
     (Axis(name='x', index=0, labels=None), Axis(name='y', index=1, labels=None), Axis(name='z', index=2, labels=None))
@@ -136,29 +155,28 @@ It is also possible to use labels in any of the slicing syntax above:
 .. doctest::
 
     >>> time_caps #doctest: +NORMALIZE_WHITESPACE
-    DataArray([[ 0,  1,  2,  3,  4],
-     [ 5,  6,  7,  8,  9],
-     [10, 11, 12, 13, 14],
-     [15, 16, 17, 18, 19]])
-    ('time', 'capitals')
+    DataArray(array([[ 0,  1,  2,  3,  4],
+           [ 5,  6,  7,  8,  9],
+           [10, 11, 12, 13, 14],
+           [15, 16, 17, 18, 19]]),
+    (('time', ('0015', '0615', '1215', '1815')), ('capitals', ('washington', 'london', 'berlin', 'paris', 'moscow'))))
     >>> time_caps.axes.capitals['berlin'::-1] #doctest: +NORMALIZE_WHITESPACE
-    DataArray([[ 2,  1,  0],
-     [ 7,  6,  5],
-     [12, 11, 10],
-     [17, 16, 15]])
-    ('time', 'capitals')
+    DataArray(array([[ 2,  1,  0],
+           [ 7,  6,  5],
+           [12, 11, 10],
+           [17, 16, 15]]),
+    (('time', ('0015', '0615', '1215', '1815')), ('capitals', ('berlin', 'london', 'washington'))))
     >>> time_caps.axes.time['0015':'1815'] #doctest: +NORMALIZE_WHITESPACE
-    DataArray([[ 0,  1,  2,  3,  4],
-     [ 5,  6,  7,  8,  9],
-     [10, 11, 12, 13, 14]])
-    ('time', 'capitals')
+    DataArray(array([[ 0,  1,  2,  3,  4],
+           [ 5,  6,  7,  8,  9],
+           [10, 11, 12, 13, 14]]),
+    (('time', ('0015', '0615', '1215')), ('capitals', ('washington', 'london', 'berlin', 'paris', 'moscow'))))
     >>> time_caps[:, 'london':3] #doctest: +NORMALIZE_WHITESPACE
-    DataArray([[ 1,  2],
-     [ 6,  7],
-     [11, 12],
-     [16, 17]])
-    ('time', 'capitals')
-
+    DataArray(array([[ 1,  2],
+           [ 6,  7],
+           [11, 12],
+           [16, 17]]),
+    (('time', ('0015', '0615', '1215', '1815')), ('capitals', ('london', 'berlin'))))
 
 The .start and .stop attributes of the slice object can be either None, an
 integer index, or a valid tick. They may even be mixed. *The .step attribute,
@@ -223,29 +241,34 @@ to be compatible with the larger DataArray:
     >>> a = DataArray(np.ones((3,)), axes=('y',))
     >>> res = 2*b - a
     >>> res    # doctest: +NORMALIZE_WHITESPACE
-    DataArray([[ 1.,  1.,  1.],
-     [ 1.,  1.,  1.],
-     [ 1.,  1.,  1.]])
-    ('x', 'y')
+    DataArray(array([[ 1.,  1.,  1.],
+           [ 1.,  1.,  1.],
+           [ 1.,  1.,  1.]]),
+    ('x', 'y'))
 
 When there are unnamed dimensions, they also must be consistently oriented
-across arrays when broadcasting::
+across arrays when broadcasting:
+
+.. doctest::
 
     >>> b = DataArray(np.arange(24).reshape(3,2,4), ['x', None, 'y'])
     >>> a = DataArray(np.arange(8).reshape(2,4), [None, 'y'])
     >>> res = a + b
     >>> res
-    DataArray([[[ 0,  2,  4,  6],
-	    [ 8, 10, 12, 14]],
+    DataArray(array([[[ 0,  2,  4,  6],
+            [ 8, 10, 12, 14]],
     <BLANKLINE>
-	   [[ 8, 10, 12, 14],
-	    [16, 18, 20, 22]],
+           [[ 8, 10, 12, 14],
+            [16, 18, 20, 22]],
     <BLANKLINE>
-	   [[16, 18, 20, 22],
-	    [24, 26, 28, 30]]])
-    ('x', None, 'y')
+           [[16, 18, 20, 22],
+            [24, 26, 28, 30]]]),
+    ('x', None, 'y'))
 
-We already know that if the dimension names don't match, this won't be allowed (even though the shapes are correct)::
+We already know that if the dimension names don't match, this won't be allowed
+(even though the shapes are correct):
+
+.. doctest::
 
     >>> b = DataArray(np.ones((3,3)), axes=('x','y'))
     >>> a = DataArray(np.ones((3,)), axes=('x',))
@@ -260,10 +283,10 @@ But a numpy idiom for padding dimensions helps us in this case:
 
     >>> res = 2*b - a[:,None]
     >>> res    # doctest: +NORMALIZE_WHITESPACE
-    DataArray([[ 1.,  1.,  1.],
-     [ 1.,  1.,  1.],
-     [ 1.,  1.,  1.]])
-    ('x', 'y')
+    DataArray(array([[ 1.,  1.,  1.],
+           [ 1.,  1.,  1.],
+           [ 1.,  1.,  1.]]),
+    ('x', 'y'))
 
 In other words, this scenario is also a legal combination:
 
@@ -273,10 +296,10 @@ In other words, this scenario is also a legal combination:
     >>> a2.names
     ('x', None)
     >>> b + a2    # doctest: +NORMALIZE_WHITESPACE
-    DataArray([[ 2.,  2.,  2.],
-     [ 2.,  2.,  2.],
-     [ 2.,  2.,  2.]])
-    ('x', 'y')
+    DataArray(array([[ 2.,  2.,  2.],
+           [ 2.,  2.,  2.],
+           [ 2.,  2.,  2.]]),
+    ('x', 'y'))
 
 The rule for dimension compatibility is that any two axes match if one of the following is true
 
@@ -292,10 +315,10 @@ The rule for dimension compatibility is that any two axes match if one of the fo
     >>> b = DataArray(np.ones((3,3)), axes=('x','y'))
     >>> a = DataArray(np.ones((3,1)), axes=('x','y'))
     >>> a+b          # doctest: +NORMALIZE_WHITESPACE
-    DataArray([[ 2.,  2.,  2.],
-     [ 2.,  2.,  2.],
-     [ 2.,  2.,  2.]])
-    ('x', 'y')
+    DataArray(array([[ 2.,  2.,  2.],
+           [ 2.,  2.,  2.],
+           [ 2.,  2.,  2.]]),
+    ('x', 'y'))
 
 The broadcasting rules currently allow this combination. I'm inclined to allow
 it. Even though the axes are different lengths in ``a`` and ``b``, and
@@ -307,60 +330,64 @@ information collision from ``a.axes.y``.
 Iteration
 =========
 
-seems to work::
+seems to work:
+
+.. doctest::
 
     >>> for foo in time_caps:
     ...     print foo
     ...     print foo.axes
     ...
-    [0 1 2 3 4]
-    ('capitals',)
+    DataArray([0 1 2 3 4],
+    (('capitals', ('washington', 'london', 'berlin', 'paris', 'moscow')),))
     (Axis(name='capitals', index=0, labels=['washington', 'london', 'berlin', 'paris', 'moscow']),)
-    [5 6 7 8 9]
-    ('capitals',)
+    DataArray([5 6 7 8 9],
+    (('capitals', ('washington', 'london', 'berlin', 'paris', 'moscow')),))
     (Axis(name='capitals', index=0, labels=['washington', 'london', 'berlin', 'paris', 'moscow']),)
-    [10 11 12 13 14]
-    ('capitals',)
+    DataArray([10 11 12 13 14],
+    (('capitals', ('washington', 'london', 'berlin', 'paris', 'moscow')),))
     (Axis(name='capitals', index=0, labels=['washington', 'london', 'berlin', 'paris', 'moscow']),)
-    [15 16 17 18 19]
-    ('capitals',)
+    DataArray([15 16 17 18 19],
+    (('capitals', ('washington', 'london', 'berlin', 'paris', 'moscow')),))
     (Axis(name='capitals', index=0, labels=['washington', 'london', 'berlin', 'paris', 'moscow']),)
 
     >>> for foo in time_caps.T:
     ...    print foo
     ...    print foo.axes
     ...
-    [ 0  5 10 15]
-    ('time',)
+    DataArray([ 0  5 10 15],
+    (('time', ('0015', '0615', '1215', '1815')),))
     (Axis(name='time', index=0, labels=['0015', '0615', '1215', '1815']),)
-    [ 1  6 11 16]
-    ('time',)
+    DataArray([ 1  6 11 16],
+    (('time', ('0015', '0615', '1215', '1815')),))
     (Axis(name='time', index=0, labels=['0015', '0615', '1215', '1815']),)
-    [ 2  7 12 17]
-    ('time',)
+    DataArray([ 2  7 12 17],
+    (('time', ('0015', '0615', '1215', '1815')),))
     (Axis(name='time', index=0, labels=['0015', '0615', '1215', '1815']),)
-    [ 3  8 13 18]
-    ('time',)
+    DataArray([ 3  8 13 18],
+    (('time', ('0015', '0615', '1215', '1815')),))
     (Axis(name='time', index=0, labels=['0015', '0615', '1215', '1815']),)
-    [ 4  9 14 19]
-    ('time',)
+    DataArray([ 4  9 14 19],
+    (('time', ('0015', '0615', '1215', '1815')),))
     (Axis(name='time', index=0, labels=['0015', '0615', '1215', '1815']),)
 
-Or even more conveniently::
+Or even more conveniently:
+
+.. doctest::
 
     >>> for foo in time_caps.axes.capitals:
     ...     print foo
     ...
-    [ 0  5 10 15]
-    ('time',)
-    [ 1  6 11 16]
-    ('time',)
-    [ 2  7 12 17]
-    ('time',)
-    [ 3  8 13 18]
-    ('time',)
-    [ 4  9 14 19]
-    ('time',)
+    DataArray([ 0  5 10 15],
+    (('time', ('0015', '0615', '1215', '1815')),))
+    DataArray([ 1  6 11 16],
+    (('time', ('0015', '0615', '1215', '1815')),))
+    DataArray([ 2  7 12 17],
+    (('time', ('0015', '0615', '1215', '1815')),))
+    DataArray([ 3  8 13 18],
+    (('time', ('0015', '0615', '1215', '1815')),))
+    DataArray([ 4  9 14 19],
+    (('time', ('0015', '0615', '1215', '1815')),))
 
 .. _transposition:
 
@@ -368,7 +395,9 @@ Transposition of Axes
 =====================
 
 Transposition of a DataArray preserves the dimension names, and updates the
-corresponding indices::
+corresponding indices:
+
+.. doctest::
 
     >>> b = DataArray(np.zeros((3, 2, 4)), axes=['x', None, 'y'])
     >>> b.shape

--- a/examples/inference_algs.py
+++ b/examples/inference_algs.py
@@ -1,4 +1,9 @@
 from __future__ import division
+
+import sys
+if sys.version_info[0] < 3:  # Use range iterator for Python 2
+    range = xrange
+
 import networkx as nx, numpy as np,itertools as it, operator as op
 from datarray import DataArray
 from numpy.testing import assert_almost_equal
@@ -412,7 +417,7 @@ def triangulate_min_fill(G):
     """
     G_elim = nx.Graph(G.edges())
     added_edges = []
-    for _ in xrange(G.number_of_nodes()):
+    for _ in range(G.number_of_nodes()):
         nodes,degrees = zip(*G_elim.degree().items())
         min_deg_node = nodes[np.argmin(degrees)]
         new_edges = [(n1,n2) for (n1,n2) in


### PR DESCRIPTION
Fix a bug in sorting of axes that was causing test errors sometimes.

Adapt to Numpy >= 1.7 by having our own implementation of ``std``.

Finish up port to common Python 2 / 3 codebase.