### PR TITLE
RF+BF: add any and all as reductions

### DIFF
--- a/datarray/datarray.py
+++ b/datarray/datarray.py
@@ -716,10 +716,11 @@ def _apply_reduction(opname, kwnames):
         # try to convert a named Axis to an integer..
         # don't try to catch an error
         axis_idx = _names_to_numbers(inst.axes, [axis])[0]
-        axes = _pull_axis(axes, inst.axes[axis_idx])
+        if not kwargs.get('keepdims', False):
+            axes = _pull_axis(axes, inst.axes[axis_idx])
         kwargs['axis'] = axis_idx
         arr = super_op(inst, **kwargs)
-        if not is_numpy_scalar(arr): 
+        if not is_numpy_scalar(arr):
             _set_axes(arr, axes)
         return arr
     runs_op.func_name = opname
@@ -1179,8 +1180,8 @@ class DataArray(np.ndarray):
         return arr
 
     # -- Reductions ----------------------------------------------------------
-    mean = _apply_reduction('mean', ('axis', 'dtype', 'out'))
-    var = _apply_reduction('var', ('axis', 'dtype', 'out', 'ddof'))
+    mean = _apply_reduction('mean', ('axis', 'dtype', 'out', 'keepdims'))
+    var = _apply_reduction('var', ('axis', 'dtype', 'out', 'ddof', 'keepdims'))
 
     def std(self, *args, **kwargs):
         ret = self.var(*args, **kwargs)
@@ -1193,19 +1194,19 @@ class DataArray(np.ndarray):
         return ret
     std.__doc__ = np.ndarray.std.__doc__
 
-    min = _apply_reduction('min', ('axis', 'out'))
-    max = _apply_reduction('max', ('axis', 'out'))
+    min = _apply_reduction('min', ('axis', 'out', 'keepdims'))
+    max = _apply_reduction('max', ('axis', 'out', 'keepdims'))
 
-    sum = _apply_reduction('sum', ('axis', 'dtype', 'out'))
-    prod = _apply_reduction('prod', ('axis', 'dtype', 'out'))
+    sum = _apply_reduction('sum', ('axis', 'dtype', 'out', 'keepdims'))
+    prod = _apply_reduction('prod', ('axis', 'dtype', 'out', 'keepdims'))
 
-    all = _apply_reduction('all', ('axis', 'dtype', 'out'))
-    any = _apply_reduction('any', ('axis', 'dtype', 'out'))
+    all = _apply_reduction('all', ('axis', 'dtype', 'out', 'keepdims'))
+    any = _apply_reduction('any', ('axis', 'dtype', 'out', 'keepdims'))
 
     ### these change the meaning of the axes..
     ### should probably return ndarrays
-    argmax = _apply_reduction('argmax', ('axis',))
-    argmin = _apply_reduction('argmin', ('axis',))
+    argmax = _apply_reduction('argmax', ('axis', 'out'))
+    argmin = _apply_reduction('argmin', ('axis', 'out'))
 
     # -- Accumulations -------------------------------------------------------
     cumsum = _apply_accumulation('cumsum', ('axis', 'dtype', 'out'))

--- a/datarray/datarray.py
+++ b/datarray/datarray.py
@@ -92,13 +92,10 @@ class AxesManager(object):
     An axis can be indexed by integers or ticks:
 
     >>> np.all(A.axes.stocks['aapl':'goog'] == A.axes.stocks[0:2])
-    DataArray(array(True, dtype=bool),
-    ('date', ('stocks', ('aapl', 'ibm')), 'metric'))
+    True
 
     >>> np.all(A.axes.stocks[0:2] == A[:,0:2,:])
-    DataArray(array(True, dtype=bool),
-    ('date', ('stocks', ('aapl', 'ibm')), 'metric'))
-
+    True
 
     Axes can also be accessed numerically:
 
@@ -111,8 +108,7 @@ class AxesManager(object):
 
     >>> Ai = A.axes('stocks', 'date')
     >>> np.all(Ai['aapl':'goog', 100] == A[100, 0:2])
-    DataArray(array(True, dtype=bool),
-    (('stocks', ('aapl', 'ibm')), 'metric'))
+    True
 
     You can also mix axis names and integers when calling AxesManager.
     (Not yet supported.)
@@ -414,19 +410,15 @@ class Axis(object):
         >>> A = DataArray(np.arange(2*3*2).reshape([2,3,2]), \
                 ('a', ('b', ('b1','b2','b3')), 'c'))
         >>> b = A.axes.b
-       
+
         >>> np.all(b['b1'] == A[:,0,:])
-        DataArray(array(True, dtype=bool),
-        ('a', 'c'))
+        True
 
         >>> np.all(b['b2':] == A[:,1:,:])
-        DataArray(array(True, dtype=bool),
-        ('a', ('b', ('b2', 'b3')), 'c'))
+        True
 
         >>> np.all(b['b1':'b2'] == A[:,0:1,:])
-        DataArray(array(True, dtype=bool),
-        ('a', ('b', ('b1',)), 'c'))
-
+        True
         """
         # XXX We don't handle fancy indexing at the moment
         if isinstance(key, (np.ndarray, list)):
@@ -608,8 +600,7 @@ class Axis(object):
         >>> arr1 = darr.axes.b.keep(['c','d'])
         >>> arr2 = darr.axes.b.drop(['a','b','e'])
         >>> np.all(arr1 == arr2)
-        DataArray(array(True, dtype=bool),
-        ('a', ('b', ('c', 'd'))))
+        True
         """
 
         if not self.labels:
@@ -1207,6 +1198,9 @@ class DataArray(np.ndarray):
 
     sum = _apply_reduction('sum', ('axis', 'dtype', 'out'))
     prod = _apply_reduction('prod', ('axis', 'dtype', 'out'))
+
+    all = _apply_reduction('all', ('axis', 'dtype', 'out'))
+    any = _apply_reduction('any', ('axis', 'dtype', 'out'))
 
     ### these change the meaning of the axes..
     ### should probably return ndarrays

--- a/datarray/tests/test_data_array.py
+++ b/datarray/tests/test_data_array.py
@@ -266,7 +266,7 @@ def test_swapaxes():
 
 other_wraps = ['argmax', 'argmin']
 reductions = ['mean', 'var', 'std', 'min',
-              'max', 'sum', 'prod', 'ptp']
+              'max', 'sum', 'prod', 'ptp', 'any', 'all']
 accumulations = ['cumprod', 'cumsum']
 
 methods = other_wraps + reductions + accumulations

--- a/datarray/tests/test_data_array.py
+++ b/datarray/tests/test_data_array.py
@@ -5,11 +5,18 @@ PY3 = sys.version_info[0] >= 3
 
 import numpy as np
 
-from datarray.datarray import Axis, DataArray, NamedAxisError, \
-    _pull_axis, _reordered_axes
+from datarray.datarray import (Axis, DataArray, NamedAxisError, AxesManager,
+                               _pull_axis, _reordered_axes)
 
 import nose.tools as nt
 import numpy.testing as npt
+
+DA = DataArray(np.random.randn(4, 2, 6), 'xyz')
+YZ = AxesManager(DA, (Axis('y', 0, None), Axis('z', 1, None)))
+XZ = AxesManager(DA, (Axis('x', 0, None), Axis('z', 1, None)))
+XY = AxesManager(DA, (Axis('x', 0, None), Axis('y', 1, None)))
+AXES_REMOVED = dict(x=YZ, y=XZ, z=XY)
+
 
 def test_axis_equal():
     ax1 = Axis('aname', 0, None)
@@ -264,52 +271,71 @@ def test_swapaxes():
 
 # -- Tests for wrapped ndarray methods ---------------------------------------
 
-other_wraps = ['argmax', 'argmin']
 reductions = ['mean', 'var', 'std', 'min',
-              'max', 'sum', 'prod', 'ptp', 'any', 'all']
+              'max', 'sum', 'prod', 'ptp', 'any', 'all',
+              'argmax', 'argmin']
 accumulations = ['cumprod', 'cumsum']
 
-methods = other_wraps + reductions + accumulations
+methods = reductions + accumulations
 
-def assert_data_correct(d_arr, op, axis):
-    from datarray.datarray import _names_to_numbers 
+def check_data_axes(d_arr, op, axis, exp_axes, *args, **kwargs):
+    """ Check data and axes correct after operation `op`
+    """
+    from datarray.datarray import _names_to_numbers
     super_opr = getattr(np.ndarray, op)
     axis_idx = _names_to_numbers(d_arr.axes, [axis])[0]
-    d1 = super_opr(np.asarray(d_arr), axis=axis_idx)
+    d1 = super_opr(np.asarray(d_arr), axis_idx, *args, **kwargs)
     opr = getattr(d_arr, op)
-    d2 = np.asarray(opr(axis=axis))
-    assert (d1==d2).all(), 'data computed incorrectly on operation %s'%op
+    d_arr_out = opr(axis, *args, **kwargs)
+    nt.assert_equal(d_arr_out.axes, exp_axes)
+    d2 = np.asarray(d_arr_out)
+    npt.assert_equal(d1.shape, d2.shape)
+    npt.assert_array_equal(d1, d2)
 
-def assert_axes_correct(d_arr, op, axis):
-    from datarray.datarray import _names_to_numbers, _pull_axis
-    opr = getattr(d_arr, op)
-    d = opr(axis=axis)
-    axis_idx = _names_to_numbers(d_arr.axes, [axis])[0]
-    if op not in accumulations:
-        axes = _pull_axis(d_arr.axes, d_arr.axes[axis_idx])
-    else:
-        axes = d_arr.axes
-    assert all( [ax1==ax2 for ax1, ax2 in zip(d.axes, axes)] ), \
-           'mislabeled axes from operation %s'%op
 
 def test_wrapped_ops_data():
     a = DataArray(np.random.randn(4,2,6), 'xyz')
     for m in methods:
-        assert_data_correct(a, m, 'x')
-    for m in methods:
-        assert_data_correct(a, m, 'y')
-    for m in methods:
-        assert_data_correct(a, m, 'z')
+        check_data_axes(a, m, 'x', YZ if m in reductions else DA.axes)
+        check_data_axes(a, m, 'y', XZ if m in reductions else DA.axes)
+        check_data_axes(a, m, 'z', XY if m in reductions else DA.axes)
 
-def test_wrapped_ops_axes():
-    a = DataArray(np.random.randn(4,2,6), 'xyz')
-    for m in methods:
-        assert_axes_correct(a, m, 'x')
-    for m in methods:
-        assert_axes_correct(a, m, 'y')
-    for m in methods:
-        assert_axes_correct(a, m, 'z')
-    
+
+def test_reductions_keepdims():
+    names = 'xyz'
+    a = np.arange(24).reshape((2, 3, 4))
+    da = DataArray(a, names)
+    for idx, name in enumerate(names):
+        axes_removed = AXES_REMOVED[name]
+        # Test keepdims as kwarg
+        for method in reductions:
+            check_data_axes(da, method, name, axes_removed)
+            if method not in ('ptp', 'argmin', 'argmax'):
+                # Reductions taking keepdims argument
+                check_data_axes(da, method, name, DA.axes, keepdims=True)
+        # Test the individual functions with positional args
+        dt = np.dtype(float)
+        out = np.mean(da, axis=name)
+        kd_out = DataArray(np.mean(a, axis=idx, keepdims=True), names)
+        # Functions with signature axis, dtype, out, keepdims
+        for method in ('mean', 'sum', 'prod', 'all', 'any'):
+            check_data_axes(da, method, name, axes_removed, dt, out)
+            check_data_axes(da, method, name, DA.axes, dt, kd_out, True)
+        # Signature axis, out, dtype, ddof, keepdims
+        for method in ('var', 'std'):
+            check_data_axes(da, method, name, axes_removed, dt, out, 0)
+            check_data_axes(da, method, name, DA.axes, dt, kd_out, 0, True)
+        # Signature axis, out, keepdims
+        for method in ('min', 'max'):
+            check_data_axes(da, method, name, axes_removed, out)
+            check_data_axes(da, method, name, DA.axes, kd_out, True)
+        # Test reductions not using keepdims
+        out_int = out.astype(np.intp)  # argmin/max have integer output
+        for method in ('argmin', 'argmax'):
+            check_data_axes(da, method, name, axes_removed, out_int)
+        check_data_axes(da, 'ptp', name, axes_removed, out)
+
+
 # -- Tests for slicing with "newaxis" ----------------------------------------
 def test_newaxis_slicing():
     b = DataArray([[1,2],[3,4],[5,6]], 'xy')


### PR DESCRIPTION
`any` and `all` are also reductions.  You can see from the edited
doctests here that datarray was leaving axes in place when the
dimensions had been lost in the reducton.  Add `any` and `all` as
reductions, and adapt doctests.